### PR TITLE
Corrected url typo

### DIFF
--- a/upload-cordova.js
+++ b/upload-cordova.js
@@ -368,7 +368,7 @@ MediaUploader.prototype.buildQuery_ = function(params) {
  * @return {string} URL
  */
 MediaUploader.prototype.buildUrl_ = function(id, params, baseUrl) {
-  var url = baseUrl || 'https://api.vimeo.com/me/videos';
+  var url = baseUrl || 'https://api.vimeo.com/me/videos/';
   if (id) {
     url += id;
   }


### PR DESCRIPTION
In case of PUT request, the URL being sent was like 'https://api.vimeo.com/me/videos123456'. Now it is corrected to 'https://api.vimeo.com/me/videos/123456'
